### PR TITLE
Bump pax logging version to clear log4shell vulnerability

### DIFF
--- a/causalpath-cytoscape-app/pom.xml
+++ b/causalpath-cytoscape-app/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
-            <version>1.5.2</version>
+            <version>1.11.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/causalpath-cytoscape-app/pom.xml
+++ b/causalpath-cytoscape-app/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
-            <version>1.11.11</version>
+            <version>1.11.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Hi Augustin!
Please consider this PR as soon as possible and upload a new version or your app to the Cytoscape App Store.
https://apps.cytoscape.org/apps/causalpathcytoscapeapp